### PR TITLE
Modify factorization and bug in is_factored

### DIFF
--- a/context_free_languages/tests/devices/grammar_tests.cpp
+++ b/context_free_languages/tests/devices/grammar_tests.cpp
@@ -907,7 +907,7 @@ TEST_CASE("Grammar: Factor a grammar", "[grammar][function]")
         ContextFree::terminal_set_type new_vt{a, b, epsilon};
         ContextFree::production_map_type new_prods;
         new_prods[S] = {prod_aS0};
-        new_prods[S0] = {prod_b, prod_ep};
+        new_prods[S0] = {prod_A, prod_ep};
         new_prods[A] = {prod_b};
 
 
@@ -950,15 +950,18 @@ TEST_CASE("Grammar: Factor a grammar", "[grammar][function]")
         ContextFree::non_terminal_set_type new_vn{S, A, B, S0, B0};
         ContextFree::production_map_type new_prods;
         new_prods[S] = {prod_aS_l};
-        new_prods[S0] = {prod_A, prod_S, prod_ep};
+        new_prods[S0] = {prod_A, prod_B};
         new_prods[A] = {prod_bA, prod_ep};
         new_prods[B] = {prod_cB_l};
         new_prods[B0] = {prod_S, prod_ep};
 
         ContextFree grammar_2{new_vn, vt, new_prods, S};
 
+        new_grammar.is_factored();
         CHECK(new_grammar.is_factored());
         CHECK(new_grammar == grammar_2);
+        CHECK(new_grammar.vn() == new_vn);
+        CHECK(new_grammar.productions() == new_prods);
     }
 }
 


### PR DESCRIPTION
To factor now it is necessary that the grammar be epsilon-free.
And the is_factored function has been modified so as not to look
at the intersection of the symbols S and A (S-> A) but rather if
the first one of A. has already been visited.